### PR TITLE
(fix) Not caching collection

### DIFF
--- a/lib/jekyll-notion/generator.rb
+++ b/lib/jekyll-notion/generator.rb
@@ -66,7 +66,7 @@ module JekyllNotion
     end
 
     def collection
-      @collection ||= @site.collections[collection_name]
+      @site.collections[collection_name]
     end
 
     def config


### PR DESCRIPTION
Caching the current collection in the generator class dissociates the collection from the new site created by the jekyll watcher.
Solution: no caching the collection.