### PR TITLE
(fix) YAML Exception reading found unexpected

### DIFF
--- a/lib/jekyll-notion/notion_page.rb
+++ b/lib/jekyll-notion/notion_page.rb
@@ -87,7 +87,7 @@ module JekyllNotion
         end
 
         def files(prop)
-          files = prop.files.map { |f| f.file.url }.join(", ")
+          files = prop.files.map { |f| "\"#{f.file.url}\"" }.join(", ")
           "[#{files}]"
         end
 


### PR DESCRIPTION
fix: YAML Exception reading found unexpected : while scanning a plain scalar.

When running in Linux distributions (concretely alpine) happens a reading exception when reading the files property with complex URL files.