### PR TITLE
prefetch_mode implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ notion:
     - id: b0e688e199af4295ae80b67eb52f2e2f
     - id: 2190450d4cb34739a5c8340c4110fe21
       collection: recipes
-    - id: e42383cd49754897b967ce453760499f 
+    - id: e42383cd49754897b967ce453760499f
       collection: films
 ```
 
-After running `jekyll build` (or `serve`) command, the `posts`, `recipes` and `films` collections will be loaded with pages from the notion databases. 
+After running `jekyll build` (or `serve`) command, the `posts`, `recipes` and `films` collections will be loaded with pages from the notion databases.
 
 #### Database options
 
@@ -195,6 +195,26 @@ If you're not interested in the cache or you just want to disable it, set the ˋ
 ```yaml
 notion:
   cache: false
+```
+
+### Fetch mode
+
+By default, plugin works so that during the build it pulls all the stuff from
+Notion and stores results in the cache. They won't be stored in your site's
+repository.
+
+If you want to configure the sync so your Notion's content will be under git
+control, then fetch mode comes in handy. While this mode is enabled, during
+the build plugin does nothing but instead it makes command `jekyll fetch_notion`
+available which will download all the markdown content according to database
+configuration (currently only database fetching is implemented) and place
+it in corresponding source directories.
+
+To make it enabled, the following configuration must be set:
+
+```yaml
+notion:
+  fetch_mode: true
 ```
 
 ## Notion properties

--- a/lib/jekyll-notion.rb
+++ b/lib/jekyll-notion.rb
@@ -6,6 +6,7 @@ require "notion_to_md"
 require "logger"
 require "jekyll-notion/generator"
 require "vcr"
+require "jekyll-notion/commands/fetch_content"
 
 NotionToMd::Logger.level = Logger::ERROR
 
@@ -26,4 +27,5 @@ module JekyllNotion
   autoload :NotionDatabase, "jekyll-notion/notion_database"
   autoload :NotionPage, "jekyll-notion/notion_page"
   autoload :Cacheable, "jekyll-notion/cacheable"
+  autoload :FileCreator, "jekyll-notion/file_creator"
 end

--- a/lib/jekyll-notion/commands/fetch_content.rb
+++ b/lib/jekyll-notion/commands/fetch_content.rb
@@ -1,0 +1,51 @@
+module JekyllNotion
+  class FetchCommand < Jekyll::Command
+
+    def self.init_with_program(p)
+      p.command(:fetch_notion) do |c|
+        c.syntax "fetch_notion [options]"
+        c.description 'Fetches Notion content and places it in collection\'s directory'
+
+        c.action do |args, options|
+          process(args, options)
+        end
+      end
+    end
+
+    def self.process(args = [], options = {})
+      @config = configuration_from_options(options)
+
+      return unless notion_token? && fetch_mode?
+
+      config_databases.each do |db_config|
+        db = NotionDatabase.new(:config => db_config)
+        CollectionGenerator.new(:notion_resource => db, :site => nil, :plugin => nil, :config => @config, :fetch_mode => true).generate
+      end
+    end
+
+    def self.fetch_mode?
+      return true if @config["notion"]["fetch_mode"] == true
+
+      Jekyll.logger.warn("Jekyll Notion:", "fetch_mode should be true to use this command.")
+      false
+    end
+
+    def self.notion_token?
+      if ENV["NOTION_TOKEN"].nil? || ENV["NOTION_TOKEN"].empty?
+        Jekyll.logger.warn("Jekyll Notion:", "NOTION_TOKEN not provided. Cannot read from Notion.")
+        return false
+      end
+      true
+    end
+
+    def self.config_databases
+      if @config["notion"]["database"]
+        Jekyll.logger.warn("Jekyll Notion:",
+                           "database property is deprecated, use databases instead.")
+      end
+
+      @config["notion"]["databases"] || []
+    end
+
+  end
+end

--- a/lib/jekyll-notion/commands/fetch_content.rb
+++ b/lib/jekyll-notion/commands/fetch_content.rb
@@ -17,6 +17,10 @@ module JekyllNotion
 
       return unless notion_token? && fetch_mode?
 
+      # requires plugins (and _plugins/ directory) to be able to
+      # define custom notion_to_md blocks via monkey-patching
+      site = Jekyll::Site.new(@config)
+
       config_databases.each do |db_config|
         db = NotionDatabase.new(:config => db_config)
         CollectionGenerator.new(:notion_resource => db, :site => nil, :plugin => nil, :config => @config, :fetch_mode => true).generate

--- a/lib/jekyll-notion/factories/database_factory.rb
+++ b/lib/jekyll-notion/factories/database_factory.rb
@@ -5,7 +5,7 @@ module JekyllNotion
     def self.for(notion_resource:, site:, plugin:)
       if notion_resource.data_name.nil?
         CollectionGenerator.new(:notion_resource => notion_resource, :site => site,
-                                :plugin => plugin)
+                                :plugin => plugin, :config => site.config, :fetch_mode => false)
       else
         DataGenerator.new(:notion_resource => notion_resource, :site => site, :plugin => plugin)
       end

--- a/lib/jekyll-notion/file_creator.rb
+++ b/lib/jekyll-notion/file_creator.rb
@@ -1,0 +1,29 @@
+module JekyllNotion
+  class FileCreator
+    attr_reader :path, :content
+    def initialize(path, content)
+      @path = path
+      @content = content
+    end
+
+    def create!
+      ensure_directory_exists
+      write_file
+    end
+
+    private
+
+    def ensure_directory_exists
+      dir = File.dirname @path
+      FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+    end
+
+    def write_file
+      File.open(@path, "w") do |f|
+        f.puts(@content)
+      end
+
+      Jekyll.logger.info "File #{@path} #{"OK".green}"
+    end
+  end
+end

--- a/lib/jekyll-notion/generator.rb
+++ b/lib/jekyll-notion/generator.rb
@@ -7,7 +7,7 @@ module JekyllNotion
     def generate(site)
       @site = site
 
-      return unless notion_token? && config?
+      return unless notion_token? && config? && !fetch_mode?
 
       setup
 
@@ -72,6 +72,14 @@ module JekyllNotion
 
     def config
       @config ||= @site.config["notion"] || {}
+    end
+
+    def fetch_mode?
+      if config["fetch_mode"] == true
+        Jekyll.logger.warn("Jekyll Notion:", "fetch_mode is true, skipping the generator.")
+        return true
+      end
+      false
     end
 
     def fetch_on_watch?


### PR DESCRIPTION
Hello! Many thanks for your plugin. I want to use it to establish sync between my notion and jekyll but I'm really missing feature implemented within this PR.

Default behavior mostly works ok but it also has some pitfalls such as depending on Notion availablility, API access and internet availability. With `prefetch_mode` you can setup the sync so all your content will be stored under the git control.

To setup my sync, I'm planning on scheduling just one more CI job which will fetch changes from Notion and `git commit`/`git push` if any.