### PR TITLE
feat: caching notion requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       jekyll (>= 3.7, < 5.0)
       notion-ruby-client (~> 1.0)
       notion_to_md (~> 2.2)
+      vcr (~> 6.2)
 
 GEM
   remote: https://rubygems.org/
@@ -159,6 +160,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    vcr (6.2.0)
     webrick (1.8.1)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ The path must be relative to the working folder.
 
 To clear the cache, delete the cache folder. If you want to remove a specific cache file, locate the file that matches the Notion resource ID and delete it.
 
+#### Disabling cache
+
+If you're not interested in the cache or you just want to disable it, set the ˋcache` option to false.
+
+```yaml
+notion:
+  cache: false
+```
+
 ## Notion properties
 
 Notion page properties are set for each document in the front matter.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ notion:
   cache_dir: another/folder
 ```
 
+The path must be relative to the working folder.
+
 #### Cleaning cache
 
 To clear the cache, delete the cache folder. If you want to remove a specific cache file, locate the file that matches the Notion resource ID and delete it.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,31 @@ notion:
 
 And that's all. Each page in the notion database will be included in the selected collection.
 
+### Cache
+
+Starting from version 2.4.0, every request to Notion is cached locally. The cache enables the retrieval of Notion resources only during the first request. Subsequent requests are fetched from the cache, which can significantly reduce build times.
+
+The cache mechanism is based on the [vcr](https://github.com/vcr/vcr) gem, which records HTTP requests. Every Notion resource, whether it is a database or page, is stored in an independent file using the document ID as the filename. For example, a database ID e42383cd49754897b967ce453760499f will be stored in the following path:
+
+```bash
+.cache/jekyll-notion/vcr_cassetes/e42383cd49754897b967ce453760499f.yml
+```
+
+**Note: The `cache` option invalidates the fetch_on_watch feature.**
+
+#### Cache folder
+
+By default, the cache folder is `.cache/jekyll-notion/vcr_cassetes`, but you can change this folder by setting the `cache_dir` property in the `_config.yml` file as follows.
+
+```yaml
+notion:
+  cache_dir: another/folder
+```
+
+#### Cleaning cache
+
+To clear the cache, delete the cache folder. If you want to remove a specific cache file, locate the file that matches the Notion resource ID and delete it.
+
 ## Notion properties
 
 Notion page properties are set for each document in the front matter.

--- a/jekyll-notion.gemspec
+++ b/jekyll-notion.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
   spec.add_dependency "notion-ruby-client", "~> 1.0"
   spec.add_dependency "notion_to_md", "~> 2.2"
+  spec.add_dependency "vcr", "~> 6.2"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/jekyll-notion.rb
+++ b/lib/jekyll-notion.rb
@@ -13,19 +13,6 @@ Notion.configure do |config|
   config.token = ENV["NOTION_TOKEN"]
 end
 
-# Using VCR to record and playback Notion API responses for caching
-#
-VCR.configure do |config|
-  config.cassette_library_dir = File.join(Dir.getwd, ".cache", "jekyll-notion", "vcr_cassettes")
-  config.hook_into :faraday # Faraday is used by notion-ruby-client gem
-  config.filter_sensitive_data("<NOTION_TOKEN>") { ENV["NOTION_TOKEN"] }
-  config.allow_http_connections_when_no_cassette = true
-  config.default_cassette_options = {
-    :allow_playback_repeats => true,
-    :record => :new_episodes
-  }
-end
-
 module JekyllNotion
   autoload :DatabaseFactory, "jekyll-notion/factories/database_factory"
   autoload :PageFactory, "jekyll-notion/factories/page_factory"
@@ -40,6 +27,3 @@ module JekyllNotion
   autoload :NotionPage, "jekyll-notion/notion_page"
   autoload :Cacheable, "jekyll-notion/cacheable"
 end
-
-# Cache Notion API responses
-Notion::Client.prepend JekyllNotion::Cacheable

--- a/lib/jekyll-notion.rb
+++ b/lib/jekyll-notion.rb
@@ -5,11 +5,25 @@ require "notion"
 require "notion_to_md"
 require "logger"
 require "jekyll-notion/generator"
+require "vcr"
 
 NotionToMd::Logger.level = Logger::ERROR
 
 Notion.configure do |config|
   config.token = ENV["NOTION_TOKEN"]
+end
+
+# Using VCR to record and playback Notion API responses for caching
+#
+VCR.configure do |config|
+  config.cassette_library_dir = File.join(Dir.getwd, ".cache", "jekyll-notion", "vcr_cassettes")
+  config.hook_into :faraday # Faraday is used by notion-ruby-client gem
+  config.filter_sensitive_data("<NOTION_TOKEN>") { ENV["NOTION_TOKEN"] }
+  config.allow_http_connections_when_no_cassette = true
+  config.default_cassette_options = {
+    :allow_playback_repeats => true,
+    :record => :new_episodes
+  }
 end
 
 module JekyllNotion
@@ -24,4 +38,8 @@ module JekyllNotion
   autoload :AbstractNotionResource, "jekyll-notion/abstract_notion_resource"
   autoload :NotionDatabase, "jekyll-notion/notion_database"
   autoload :NotionPage, "jekyll-notion/notion_page"
+  autoload :Cacheable, "jekyll-notion/cacheable"
 end
+
+# Cache Notion API responses
+Notion::Client.prepend JekyllNotion::Cacheable

--- a/lib/jekyll-notion/cacheable.rb
+++ b/lib/jekyll-notion/cacheable.rb
@@ -2,23 +2,16 @@
 #
 
 module JekyllNotion
-  # Using VCR to record and playback Notion API responses for caching
   module Cacheable
     def database_query(*args)
-      puts "==> VCR DB item fetching #{args} from Notion..."
-
       VCR.use_cassette("#{args[0][:database_id]}") { super(*args) }
     end
 
     def block_children(*args)
-      puts "==> VCR BLOCK CHILDREN fetching #{args} from Notion..."
-
       VCR.use_cassette("#{args[0][:block_id]}") { super(*args) }
     end
 
     def page(*args)
-      puts "==> VCR PAGE fetching #{args} from Notion..."
-
       VCR.use_cassette("#{args[0][:page_id]}") { super(*args) }
     end
   end

--- a/lib/jekyll-notion/cacheable.rb
+++ b/lib/jekyll-notion/cacheable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+#
+
+module JekyllNotion
+  # Using VCR to record and playback Notion API responses for caching
+  module Cacheable
+    def database_query(*args)
+      puts "==> VCR DB item fetching #{args} from Notion..."
+
+      VCR.use_cassette("#{args[0][:database_id]}") { super(*args) }
+    end
+
+    def block_children(*args)
+      puts "==> VCR BLOCK CHILDREN fetching #{args} from Notion..."
+
+      VCR.use_cassette("#{args[0][:block_id]}") { super(*args) }
+    end
+
+    def page(*args)
+      puts "==> VCR PAGE fetching #{args} from Notion..."
+
+      VCR.use_cassette("#{args[0][:page_id]}") { super(*args) }
+    end
+  end
+end

--- a/lib/jekyll-notion/cacheable.rb
+++ b/lib/jekyll-notion/cacheable.rb
@@ -3,6 +3,28 @@
 
 module JekyllNotion
   module Cacheable
+    def self.setup(cache_dir)
+      # Using VCR to record and playback Notion API responses for caching
+      VCR.configure do |config|
+        config.cassette_library_dir = cache_path(cache_dir)
+        config.hook_into :faraday # Faraday is used by notion-ruby-client gem
+        config.filter_sensitive_data("<NOTION_TOKEN>") { ENV["NOTION_TOKEN"] }
+        config.allow_http_connections_when_no_cassette = true
+        config.default_cassette_options = {
+          :allow_playback_repeats => true,
+          :record => :new_episodes
+        }
+      end
+    end
+
+    def self.cache_path(path = nil)
+      if path.nil?
+        File.join(Dir.getwd, ".cache", "jekyll-notion", "vcr_cassettes")
+      else
+        File.join(Dir.getwd, path)
+      end
+    end
+
     def database_query(*args)
       VCR.use_cassette("#{args[0][:database_id]}") { super(*args) }
     end

--- a/lib/jekyll-notion/generator.rb
+++ b/lib/jekyll-notion/generator.rb
@@ -9,6 +9,8 @@ module JekyllNotion
 
       return unless notion_token? && config?
 
+      setup
+
       if fetch_on_watch? || cache_empty?
         read_notion_databases
         read_notion_pages
@@ -90,6 +92,20 @@ module JekyllNotion
         return false
       end
       true
+    end
+
+    def setup
+      # Cache Notion API responses
+      if cache?
+        JekyllNotion::Cacheable.setup(config["cache_dir"])
+        Notion::Client.prepend JekyllNotion::Cacheable
+      end
+    end
+
+    def cache?
+      return true if config["cache"].nil?
+
+      config["cache"] == true.to_s
     end
   end
 end


### PR DESCRIPTION
Implementing a cache for every Notion requests using VCR.

Built times are more than x10 times faster with my website (20 requests to notion):
* No cache: `make build  1.58s user 0.53s system 7% cpu 28.674 total`
* Cache: `make build  1.15s user 0.44s system 73% cpu 2.157 total`

Default cache folder is found in `./.cache/jekyll-notion/vcr_cassetes`. This is what it looks like in my website:
<img width="407" alt="Screen Shot 2023-09-02 at 16 26 20" src="https://github.com/emoriarty/jekyll-notion/assets/510375/e8742d94-3d59-4194-8ee0-2fe8613008b3">


### TODOs
- [x] allow to setup where to store the cache
