### PR TITLE
refactor: cache notion request by id

### DIFF
--- a/lib/jekyll-notion/cacheable.rb
+++ b/lib/jekyll-notion/cacheable.rb
@@ -26,16 +26,8 @@ module JekyllNotion
       end
     end
 
-    def database_query(*args)
-      VCR.use_cassette((args[0][:database_id]).to_s) { super(*args) }
-    end
-
-    def block_children(*args)
-      VCR.use_cassette((args[0][:block_id]).to_s) { super(*args) }
-    end
-
-    def page(*args)
-      VCR.use_cassette((args[0][:page_id]).to_s) { super(*args) }
+    def generate(*args)
+      VCR.use_cassette(resource_id) { super(*args) }
     end
   end
 end

--- a/lib/jekyll-notion/generator.rb
+++ b/lib/jekyll-notion/generator.rb
@@ -99,7 +99,9 @@ module JekyllNotion
       # Cache Notion API responses
       if ENV["JEKYLL_ENV"] != "test" && cache?
         JekyllNotion::Cacheable.setup(config["cache_dir"])
-        Notion::Client.prepend JekyllNotion::Cacheable
+        JekyllNotion::CollectionGenerator.prepend(JekyllNotion::Cacheable)
+        JekyllNotion::PageGenerator.prepend(JekyllNotion::Cacheable)
+        JekyllNotion::DataGenerator.prepend(JekyllNotion::Cacheable)
       end
     end
 

--- a/lib/jekyll-notion/generators/abstract_generator.rb
+++ b/lib/jekyll-notion/generators/abstract_generator.rb
@@ -11,5 +11,9 @@ module JekyllNotion
     def generate
       raise "Do not use the AbstractGenerator class. Implement the generate method in a subclass."
     end
+
+    def resource_id
+      @notion_resource.id
+    end
   end
 end


### PR DESCRIPTION
Cache notion requests by notion page/database id present in `_config.yml`.

The refactor allows to better match cached file with notion resource specified in the configuration.